### PR TITLE
Fix Flux.skip(n)

### DIFF
--- a/src/__tests__/flux-test.js
+++ b/src/__tests__/flux-test.js
@@ -109,8 +109,32 @@ describe('Flux Tests', () => {
       Flux.range(1, 10)
           .take(5)
           .subscribe(ts);
-      ts.await().then(() => {
+      return ts.await().then(() => {
         ts.assertValues([1, 2, 3, 4, 5]);
+        ts.assertComplete();
+        ts.assertNoError();
+      });
+    });
+  });
+  describe('FluxSkip', () => {
+    it('normal', () => {
+      const ts = new TestSubscriber();
+      Flux.range(1, 10)
+          .skip(5)
+          .subscribe(ts);
+      return ts.await().then(() => {
+        ts.assertValues([6, 7, 8, 9, 10]);
+        ts.assertComplete();
+        ts.assertNoError();
+      });
+    });
+    it('skip all', () => {
+      const ts = new TestSubscriber();
+      Flux.range(1, 10)
+          .skip(Infinity)
+          .subscribe(ts);
+      return ts.await().then(() => {
+        ts.assertNoValues();
         ts.assertComplete();
         ts.assertNoError();
       });

--- a/src/flux-take.js
+++ b/src/flux-take.js
@@ -129,9 +129,7 @@ export class FluxSkipSubscriber<T> implements Subscriber<T>, Subscription {
     if (r != 0) {
       r--;
       this._remaining = r;
-      if (r != 0) {
-        return;
-      }
+      return;
     }
     this._actual.onNext(t);
   }


### PR DESCRIPTION
Previously flux skip would skip one less element then specified (e.g. `Flux.just('test').skip(1)` would  not skip the element)