### PR TITLE
Fix back-pressured consumption of Flux.range and Flux.array.

### DIFF
--- a/src/__tests__/flux-range-test.js
+++ b/src/__tests__/flux-range-test.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ */
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import {Flux} from '../flux';
+import {TestSubscriber} from '../subscriber'
+
+describe('Flux Range Tests', () => {
+  describe('FluxRange', () => {
+    it('normal', () => {
+      const ts = new TestSubscriber();
+      Flux.range(1, 10).subscribe(ts);
+      return ts.await().then(() => {
+        ts.assertNoError();
+        ts.assertValues([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        ts.assertComplete();
+      });
+    });
+    it('normal back-pressured', () => {
+      const ts = new TestSubscriber(0);
+      Flux.range(1, 10).subscribe(ts);
+
+      ts.assertNoValues();
+      ts.assertNoError();
+      ts.assertNotComplete();
+
+      ts.request(5);
+
+      ts.assertValues([1, 2, 3, 4, 5]);
+      ts.assertNoError();
+      ts.assertNotComplete();
+
+      ts.request(10);
+
+      ts.assertValues([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      ts.assertNoError();
+      ts.assertComplete();
+    });
+    it('normal back-pressured exact', () => {
+      const ts = new TestSubscriber(0);
+      Flux.range(1, 10).subscribe(ts);
+
+      ts.assertNoValues();
+      ts.assertNoError();
+      ts.assertNotComplete();
+
+      ts.request(10);
+
+      ts.assertValues([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      ts.assertNoError();
+      ts.assertComplete();
+    });
+    it('normal negative start', () => {
+      const ts = new TestSubscriber();
+      Flux.range(-10, 2).subscribe(ts);
+      return ts.await().then(() => {
+        ts.assertNoError();
+        ts.assertValues([-10, -9]);
+        ts.assertComplete();
+      });
+    });
+
+  });
+  describe('FluxArray', () => {
+    it('normal', () => {
+      const ts = new TestSubscriber();
+      Flux.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).subscribe(ts);
+      return ts.await().then(() => {
+        ts.assertNoError();
+        ts.assertValues([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        ts.assertComplete();
+      });
+    });
+    it('normal back-pressured', () => {
+      const ts = new TestSubscriber(0);
+      Flux.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).subscribe(ts);
+
+      ts.assertNoValues();
+      ts.assertNoError();
+      ts.assertNotComplete();
+
+      ts.request(5);
+
+      ts.assertValues([1, 2, 3, 4, 5]);
+      ts.assertNoError();
+      ts.assertNotComplete();
+
+      ts.request(10);
+
+      ts.assertValues([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      ts.assertNoError();
+      ts.assertComplete();
+    });
+    it('normal back-pressured exact', () => {
+      const ts = new TestSubscriber(0);
+      Flux.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).subscribe(ts);
+
+      ts.assertNoValues();
+      ts.assertNoError();
+      ts.assertNotComplete();
+
+      ts.request(10);
+
+      ts.assertValues([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      ts.assertNoError();
+      ts.assertComplete();
+    });
+    it('array contains null', () => {
+      const ts = new TestSubscriber();
+      Flux.fromArray([1, 2, 3, 4, 5, null, 7, 8, 9, 10]).subscribe(ts);
+
+      return ts.await().then(() => {
+        ts.assertError('element was null');
+        ts.assertValues([1, 2, 3, 4, 5]);
+        ts.assertNotComplete();
+      });
+    });
+  });
+});

--- a/src/__tests__/flux-test.js
+++ b/src/__tests__/flux-test.js
@@ -78,17 +78,6 @@ describe('Flux Tests', () => {
       });
     });
   });
-  describe('FluxRange', () => {
-    it('normal', () => {
-      const ts = new TestSubscriber();
-      Flux.range(1, 10).subscribe(ts);
-      return ts.await().then(() => {
-        ts.assertNoError();
-        ts.assertValues([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        ts.assertComplete();
-      });
-    });
-  });
   describe('FluxConcatMap', () => {
     it('normal', () => {
       const ts = new TestSubscriber();

--- a/src/flux-range.js
+++ b/src/flux-range.js
@@ -89,6 +89,7 @@ export class FluxRangeSubscription implements QueueSubscription<number> {
 
         n = this._requested;
         if (r == n) {
+          this._index = i;
           this._requested = 0;
           return;
         } else {
@@ -199,6 +200,7 @@ export class FluxArraySubscription<T> implements QueueSubscription<T> {
 
         n = this._requested;
         if (r == n) {
+          this._index = i;
           this._requested = 0;
           return;
         } else {


### PR DESCRIPTION
Previously when non exhausting demand was requested range and array would
replay values on next request.